### PR TITLE
Change fpzip version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@
 
 ### Fixed
 
-- Use patched `streamvbyte` without _static prefix, [PR-2](https://github.com/panda-official/MatrixCompressor/pull/2)
+- Use patched `streamvbyte` without _static suffix, [PR-2](https://github.com/panda-official/MatrixCompressor/pull/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,9 @@
 
 ### Added
 
-DRIFT-617: Matrix copressor initial version, [PR-1](https://github.com/panda-official/MatrixCompressor/pull/1)
+- DRIFT-617: Matrix compressor initial version, [PR-1](https://github.com/panda-official/MatrixCompressor/pull/1)
+
+
+### Fixed
+
+- Use patched `streamvbyte` without _static prefix, [PR-2](https://github.com/panda-official/MatrixCompressor/pull/2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,7 @@ add_library(${MC_TARGET_NAME}::${MC_TARGET_NAME} ALIAS ${MC_TARGET_NAME})
 
 # Set fPIC
 set_target_properties(${MC_TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(
-    streamvbyte_static
-    PROPERTIES POSITION_INDEPENDENT_CODE ON
-)
-set_property(TARGET streamvbyte_static PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS)
+set_target_properties(streamvbyte PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(fpzip PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Set compiler features
@@ -58,7 +54,7 @@ target_include_directories(
 
 # Link dependencies
 target_link_libraries(${MC_TARGET_NAME} PUBLIC blaze::blaze)
-target_link_libraries(${MC_TARGET_NAME} PRIVATE streamvbyte_static)
+target_link_libraries(${MC_TARGET_NAME} PRIVATE streamvbyte)
 target_link_libraries(${MC_TARGET_NAME} PRIVATE fpzip)
 
 if(MC_BUILD_EXAMPLES)
@@ -81,10 +77,7 @@ endif()
 include(GNUInstallDirs)
 
 # Create package targets file
-install(
-    TARGETS ${MC_TARGET_NAME} streamvbyte_static
-    EXPORT ${MC_TARGET_NAME}-target
-)
+install(TARGETS ${MC_TARGET_NAME} streamvbyte EXPORT ${MC_TARGET_NAME}-target)
 install(
     EXPORT ${MC_TARGET_NAME}-target
     FILE ${MC_TARGET_NAME}-targets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(FetchContent)
 fetchcontent_declare(
     streamvbyte
     GIT_REPOSITORY https://github.com/victor1234/streamvbyte.git
-    GIT_TAG drift-637
+    GIT_TAG reduce-libs-number
 )
 
 fetchcontent_declare(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![example workflow](https://github.com/panda-official/MatrixCompressor/actions/workflows/ci.yml/badge.svg)
 
 # MatrixCompressor
+
 Compression library to compress sparse matrices
 
 ## Features
@@ -56,5 +57,6 @@ target_link_libraries(program matrix_compressor::matrix_compressor)
 ```
 
 ## References
-(streamvbyte)[https://github.com/victor1234/streamvbyte]
-(fpzip)[https://github.com/victor1234/fpzip]
+
+- (streamvbyte)[https://github.com/victor1234/streamvbyte]
+- (fpzip)[https://github.com/victor1234/fpzip]


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Kinda bug fix

### What is the current behavior?

streamvbyte creates a static library with `_static` suffix. It missleads `conan`when we use it as in WaveletBuffer and we use 
dynamic library instead of static.

### What is the new behavior?

We patched it in @victor1234 's repos. This is the temporal solution. We need to start testing the compression,


### Does this PR introduce a breaking change?

No

### Other information:
