### PR TITLE
Use dense Blaze containers instead of sparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changed:
 
 - Optimized index compression, [PR-3](https://github.com/panda-official/MatrixCompressor/pull/3)
+- Use dense Blaze containers, [PR-4](https://github.com/panda-official/MatrixCompressor/pull/4)
 
 ## 0.1.0 - 2023-02-28
 

--- a/matrix_compressor/matrix_compressor.h
+++ b/matrix_compressor/matrix_compressor.h
@@ -33,39 +33,39 @@ class BlazeCompressor {
   BlazeCompressor() = default;
 
   /**
-   * Compress a blaze::CompressedVector<float>
+   * Compress a blaze::DynamicVector<float>
    * @param vector
    * @param precision number of bits for each float 0 -max precision, 2 - 2
    * bits,32 - 32 bits
    * @return compressed data
    */
-  ArchivedVector Compress(const blaze::CompressedVector<float>& vector,
+  ArchivedVector Compress(const blaze::DynamicVector<float>& vector,
                           int precision);
 
   /**
-   * Decompress a blaze::CompressedVector<float>
+   * Decompress a blaze::DynamicVector<float>
    * @param compressed compressed data
    * @return decompressed vector
    */
-  blaze::CompressedVector<float> Decompress(
+  blaze::DynamicVector<float> Decompress(
       const ArchivedVector& compressed_vector);
 
   /**
-   * Compress a blaze::CompressedMatrix<float>
+   * Compress a blaze::DynamicMatrix<float>
    * @param matrix
    * @param precision number of bits for each float 0 -max precision, 2 - 2
    * bita,32 - 32 bits
    * @return compressed data
    */
-  ArchivedMatrix Compress(const blaze::CompressedMatrix<float>& matrix,
+  ArchivedMatrix Compress(const blaze::DynamicMatrix<float>& matrix,
                           int precision);
 
   /**
-   * Decompress a blaze::CompressedMatrix<float>
+   * Decompress a blaze::DynamicVector<float>
    * @param compressed compressed data
    * @return decompressed matrix
    */
-  blaze::CompressedMatrix<float> Decompress(
+  blaze::DynamicMatrix<float> Decompress(
       const ArchivedMatrix& compressed_matrix);
 
  private:

--- a/sources/matrix_compressor.cpp
+++ b/sources/matrix_compressor.cpp
@@ -44,7 +44,7 @@ blaze::DynamicMatrix<float> ConvertFromCSR(const std::vector<uint32_t>& indexes,
                                            const std::vector<float>& values,
                                            const ArchivedMatrix& compressed) {
   blaze::DynamicMatrix<float> matrix(compressed.rows_number,
-                                     compressed.cols_number, 0.0f:);
+                                     compressed.cols_number, 0.0f);
 
   /* Fill */
   for (size_t i = 0; i < indexes.size(); ++i) {

--- a/sources/matrix_compressor.cpp
+++ b/sources/matrix_compressor.cpp
@@ -11,63 +11,54 @@
 namespace matrix_compressor {
 
 std::tuple<std::vector<uint32_t>, std::vector<float>> ConvertToCSR(
-    const blaze::CompressedMatrix<float>& matrix) {
+    const blaze::DynamicMatrix<float>& matrix) {
   /* Check input */
   if (matrix.rows() == 0 || matrix.columns() == 0) {
     throw std::invalid_argument("Matrix is empty");
   }
 
   /* Indexes */
+  const auto non_zeros = matrix.nonZeros();
+
   std::vector<uint32_t> indexes;
-  indexes.reserve(matrix.nonZeros());
+  indexes.reserve(non_zeros);
 
   /* Values */
   std::vector<float> values;
-  values.reserve(matrix.nonZeros());
+  values.reserve(non_zeros);
 
   /* Fill indexes and value */
-  for (size_t row = 0; row < matrix.rows(); ++row) {
-    for (auto it = matrix.begin(row); it != matrix.end(row); ++it) {
-      indexes.push_back(
-          static_cast<uint32_t>(it->index() + row * matrix.columns()));
-      values.push_back(it->value());
+  for (auto i = 0; i < matrix.rows(); ++i) {
+    for (auto j = 0; j < matrix.columns(); ++j) {
+      if (matrix(i, j) != 0) {
+        indexes.push_back(static_cast<uint32_t>(i * matrix.columns() + j));
+        values.push_back(matrix(i, j));
+      }
     }
   }
 
   return {indexes, values};
 }
 
-blaze::CompressedMatrix<float> ConvertFromCSR(
-    const std::vector<uint32_t>& indexes, const std::vector<float>& values,
-    const ArchivedMatrix& compressed) {
-  blaze::CompressedMatrix<float> matrix(compressed.rows_number,
-                                        compressed.cols_number);
-  matrix.reserve(values.size());
+blaze::DynamicMatrix<float> ConvertFromCSR(const std::vector<uint32_t>& indexes,
+                                           const std::vector<float>& values,
+                                           const ArchivedMatrix& compressed) {
+  blaze::DynamicMatrix<float> matrix(compressed.rows_number,
+                                     compressed.cols_number, 0.0f:);
 
   /* Fill */
-  size_t last_row = 0;
   for (size_t i = 0; i < indexes.size(); ++i) {
     auto row = indexes[i] / compressed.cols_number;
     auto col = indexes[i] % compressed.cols_number;
 
-    if (row > last_row) {
-      for (size_t j = last_row; j < row; ++j) {
-        // we can jump few rows but have to finalize each
-        matrix.finalize(j);
-      }
-      matrix.reserve(row, compressed.cols_number);
-      last_row = row;
-    }
-
-    matrix.append(row, col, values[i]);
+    matrix(row, col) = values[i];
   }
 
-  matrix.finalize(last_row);
   return matrix;
 }
 
 ArchivedVector BlazeCompressor::Compress(
-    const blaze::CompressedVector<float>& vector, int precision) {
+    const blaze::DynamicVector<float>& vector, int precision) {
   /* Check input */
   if (vector.size() == 0) {
     return {};
@@ -86,9 +77,11 @@ ArchivedVector BlazeCompressor::Compress(
   values.reserve(vector.nonZeros());
 
   /* Fill indexes and value */
-  for (auto it = vector.begin(); it != vector.end(); ++it) {
-    indexes.push_back(static_cast<uint32_t>(it->index()));
-    values.push_back(it->value());
+  for (auto i = 0; i < vector.size(); ++i) {
+    if (vector[i] != 0) {
+      indexes.push_back(static_cast<uint32_t>(i));
+      values.push_back(vector[i]);
+    }
   }
 
   /* Compress indexes */
@@ -104,7 +97,7 @@ ArchivedVector BlazeCompressor::Compress(
           compressed_values};
 }
 
-blaze::CompressedVector<float> BlazeCompressor::Decompress(
+blaze::DynamicVector<float> BlazeCompressor::Decompress(
     const ArchivedVector& compressed) {
   if (!compressed.is_valid) {
     return {};
@@ -121,7 +114,7 @@ blaze::CompressedVector<float> BlazeCompressor::Decompress(
   DecompressValues(compressed.values, &values);
 
   /* Create vector */
-  blaze::CompressedVector<float> vector(compressed.size);
+  blaze::DynamicVector<float> vector(compressed.size, 0.0f);
   for (size_t i = 0; i < compressed.nonzero; ++i) {
     vector[indexes[i]] = values[i];
   }
@@ -130,7 +123,7 @@ blaze::CompressedVector<float> BlazeCompressor::Decompress(
 }
 
 ArchivedMatrix BlazeCompressor::Compress(
-    const blaze::CompressedMatrix<float>& matrix, int precision) {
+    const blaze::DynamicMatrix<float>& matrix, int precision) {
   auto [indexes, values] = ConvertToCSR(matrix);
 
   ArchivedMatrix archived_matrix{
@@ -146,7 +139,7 @@ ArchivedMatrix BlazeCompressor::Compress(
   return archived_matrix;
 }
 
-blaze::CompressedMatrix<float> BlazeCompressor::Decompress(
+blaze::DynamicMatrix<float> BlazeCompressor::Decompress(
     const ArchivedMatrix& compressed) {
   if (!compressed.is_valid) {
     throw std::invalid_argument("Invalid compressed matrix");

--- a/sources/matrix_compressor.cpp
+++ b/sources/matrix_compressor.cpp
@@ -18,14 +18,12 @@ std::tuple<std::vector<uint32_t>, std::vector<float>> ConvertToCSR(
   }
 
   /* Indexes */
-  const auto non_zeros = matrix.nonZeros();
-
   std::vector<uint32_t> indexes;
-  indexes.reserve(non_zeros);
+  indexes.reserve(matrix.columns() * matrix.rows() / 2);
 
   /* Values */
   std::vector<float> values;
-  values.reserve(non_zeros);
+  values.reserve(matrix.columns() * matrix.rows() / 2);
 
   /* Fill indexes and value */
   for (auto i = 0; i < matrix.rows(); ++i) {
@@ -64,17 +62,13 @@ ArchivedVector BlazeCompressor::Compress(
     return {};
   }
 
-  if (vector.nonZeros() == 0) {
-    return {};
-  }
-
   /* Indexes */
   std::vector<uint32_t> indexes;
-  indexes.reserve(vector.nonZeros());
+  indexes.reserve(vector.size() / 2);
 
   /* Values */
   std::vector<float> values;
-  values.reserve(vector.nonZeros());
+  values.reserve(vector.size() / 2);
 
   /* Fill indexes and value */
   for (auto i = 0; i < vector.size(); ++i) {
@@ -82,6 +76,10 @@ ArchivedVector BlazeCompressor::Compress(
       indexes.push_back(static_cast<uint32_t>(i));
       values.push_back(vector[i]);
     }
+  }
+
+  if (indexes.empty()) {
+    return {};
   }
 
   /* Compress indexes */


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

The class uses sparse blaze containers. The problem is that WaveleBuffer uses dense matrixes to store subbands and we need to 
change layout for all calls. Moreover, it stores vectors as a one-column matrices and the current implementation creates a lot of raws  what is bad for performance. 

### What is the new behavior?

I changed the API and we use DynamicVector and DynamicMatrix


### Does this PR introduce a breaking change?

Yes, but the implicit type conversion should prevent compilation errors.

### Other information:
